### PR TITLE
refactor: Change TSFI's for BSI Testmapping

### DIFF
--- a/packages/cryptobox/src/Cryptobox.test.ts
+++ b/packages/cryptobox/src/Cryptobox.test.ts
@@ -50,7 +50,7 @@ describe('cryptobox.Cryptobox', () => {
   describe('decrypt', () => {
     
     // This test conforms to the following testing standards:
-    // @SF.Messages @TSFI.RESTfulAPI
+    // @SF.Messages @TSFI.RESTfulAPI @S0.3
     it("doesn't decrypt empty ArrayBuffers", async () => {
       const box = new Cryptobox(engine);
       const sessionId = 'sessionWithBob';
@@ -63,7 +63,7 @@ describe('cryptobox.Cryptobox', () => {
     });
   
     // This test conforms to the following testing standards:
-    // @SF.Messages @TSFI.RESTfulAPI
+    // @SF.Messages @TSFI.ClientRNG @S0.3
     it('throws a Proteus decryption error if you try to decrypt the same message twice', async () => {
       const alice = await createCryptobox('alice');
       await alice.create();
@@ -145,7 +145,7 @@ describe('cryptobox.Cryptobox', () => {
     });
     
     // This test conforms to the following testing standards:
-    // @SF.Messages @TSFI.RESTfulAPI
+    // @SF.Messages @TSFI.RESTfulAPI @S0.3
     it('fails to initialize a Cryptobox of which the identity is missing', async () => {
       let box = new Cryptobox(engine);
 
@@ -167,7 +167,7 @@ describe('cryptobox.Cryptobox', () => {
     });
     
     // This test conforms to the following testing standards:
-    // @SF.Messages @TSFI.RESTfulAPI
+    // @SF.Messages @TSFI.RESTfulAPI @S0.3
     it('fails to initialize a Cryptobox of which the last resort PreKey is missing', async () => {
       let box = new Cryptobox(engine);
 
@@ -237,7 +237,7 @@ describe('cryptobox.Cryptobox', () => {
       });
       
       // This test conforms to the following testing standards:
-      // @SF.Messages @TSFI.RESTfulAPI
+      // @SF.Messages @TSFI.RESTfulAPI @S0.3
       
       it('fails for outdated PreKey formats', async () => {
         const remotePreKey = {

--- a/packages/proteus/src/keys/PublicKey.test.ts
+++ b/packages/proteus/src/keys/PublicKey.test.ts
@@ -23,7 +23,7 @@ import {SecretKey} from './SecretKey';
 describe('Public Key', () => {
 
   // This test conforms to the following testing standards:
-  // @SF.Messages @TSFI.RESTfulAPI
+  // @SF.Messages @TSFI.RESTfulAPI @S0.3
   it('rejects shared secrets at the point of infinity', async () => {
     try {
       const emptyCurve = new Uint8Array([1].concat(Array.from({length: 30})));

--- a/packages/proteus/src/message/Envelope.test.ts
+++ b/packages/proteus/src/message/Envelope.test.ts
@@ -79,7 +79,7 @@ describe('Envelope', () => {
   });
 
   // This test conforms to the following testing standards:
-  // @SF.Messages @TSFI.RESTfulAPI
+  // @SF.Messages @TSFI.RESTfulAPI @S0.3
   it('fails when passing invalid input', () => {
     const empty_buffer = new ArrayBuffer(0);
     try {


### PR DESCRIPTION
# What's new in this PR?

### Issues

The TSFI's have changed for our BSI test-documentation. Because of this, we need to update the tags of some of the BSI testcases.

### Solutions

Updated the TSFI tags to the new values provided by atsec.
