### PR TITLE
chore: use realistic values in DecryptError test

### DIFF
--- a/packages/proteus/src/errors/DecryptError.test.ts
+++ b/packages/proteus/src/errors/DecryptError.test.ts
@@ -33,8 +33,8 @@ describe('DecryptError', () => {
   });
 
   describe('Wire for web compatibility', () => {
-    const errorCode = 300;
-    const errorMessage = 'The received message was too big.';
+    const errorCode = DecryptError.CODE.CASE_202;
+    const errorMessage = 'Unknown message format: The message is neither a "CipherMessage" nor a "PreKeyMessage".';
 
     it('uses the generic error class as namespace', () => {
       const error = new DecryptError.InvalidMessage(errorMessage, errorCode);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The previously used values were misleading and using the namespace of `DecodeError`.

### Solutions

Test code uses now realistic values from namespace of `DecryptError`.


Needs releases with:

- [ ] GitHub link to other pull request

#### How to Test

Covered by automatic tests, as only tests were modified.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
